### PR TITLE
Add filtering to Todo list view with default display of completed tasks

### DIFF
--- a/todo_app/templates/todo/list.html
+++ b/todo_app/templates/todo/list.html
@@ -6,6 +6,20 @@
 <body>
     <h1>My Todo List</h1>
     <a href="{% url 'todo_create' %}">Add Task</a>
+    <form method="get" id="filterForm">
+        <label>
+            <input type="radio" name="filter" value="all" {% if request.GET.filter == "all" %}checked{% endif %}>
+            Show All
+        </label>
+        <label>
+            <input type="radio" name="filter" value="completed" {% if request.GET.filter == "completed" or not request.GET.filter %}checked{% endif %}>
+            Completed
+        </label>
+        <label>
+            <input type="radio" name="filter" value="not_completed" {% if request.GET.filter == "not_completed" %}checked{% endif %}>
+            Not Completed
+        </label>
+    </form>
     <p>Number of todos: {{ todos|length }}</p>
     <ul>
         {% for todo in todos %}
@@ -26,5 +40,13 @@
             <li>No tasks yet.</li>
         {% endfor %}
     </ul>
+
+    <script>
+        document.querySelectorAll('input[name="filter"]').forEach((radio) => {
+            radio.addEventListener('change', () => {
+                document.getElementById('filterForm').submit();
+            });
+        });
+    </script>
 </body>
 </html>

--- a/todo_app/tests.py
+++ b/todo_app/tests.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
+from django.urls import reverse
 from .models import Todo
 
 class TestTodo(TestCase):
@@ -76,3 +77,90 @@ class TestTodo(TestCase):
         self.assertEqual(self.todo.task_name, 'Task')
         self.assertIsNone(self.todo.task_description)
         self.assertFalse(self.todo.is_completed)
+
+class TodoViewTests(TestCase):
+    def setUp(self):
+        self.todo_completed = Todo.objects.create(
+            task_name='Completed Task',
+            task_description='Done',
+            is_completed=True
+        )
+        self.todo_not_completed = Todo.objects.create(
+            task_name='Incomplete Task',
+            task_description='Not done yet',
+            is_completed=False
+        )
+
+    def test_todo_list_default_filter_shows_completed(self):
+        response = self.client.get(reverse('todo_list'))
+        self.assertContains(response, self.todo_completed.task_name)
+        self.assertNotContains(response, self.todo_not_completed.task_name)
+
+    def test_todo_list_filter_all(self):
+        response = self.client.get(reverse('todo_list') + '?filter=all')
+        self.assertContains(response, self.todo_completed.task_name)
+        self.assertContains(response, self.todo_not_completed.task_name)
+
+    def test_todo_list_filter_not_completed(self):
+        response = self.client.get(reverse('todo_list') + '?filter=not_completed')
+        self.assertNotContains(response, self.todo_completed.task_name)
+        self.assertContains(response, self.todo_not_completed.task_name)
+
+    def test_todo_list_filter_completed(self):
+        response = self.client.get(reverse('todo_list') + '?filter=completed')
+        self.assertContains(response, self.todo_completed.task_name)
+        self.assertNotContains(response, self.todo_not_completed.task_name)
+
+    def test_create_todo(self):
+        response = self.client.post(reverse('todo_create'), {
+            'task_name': 'New Task',
+            'task_description': 'New description',
+            'is_completed': False
+        })
+        self.assertEqual(Todo.objects.count(), 3)
+        self.assertRedirects(response, reverse('todo_list'))
+
+    def test_create_todo_with_invalid_data(self):
+        response = self.client.post(reverse('todo_create'), {
+            'task_name': '',
+            'task_description': 'New description',
+            'is_completed': False
+        })
+        self.assertEqual(Todo.objects.count(), 2)
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(response, 'form', 'task_name', 'This field is required.')
+
+    def test_update_todo(self):
+        response = self.client.post(reverse('todo_update', args=[self.todo_not_completed.id]), {
+            'task_name': 'Updated Task',
+            'task_description': 'Updated desc',
+            'is_completed': True
+        })
+        self.assertRedirects(response, reverse('todo_list'))
+        self.todo_not_completed.refresh_from_db()
+        self.assertEqual(self.todo_not_completed.task_name, 'Updated Task')
+        self.assertTrue(self.todo_not_completed.is_completed)
+
+    def test_update_todo_with_invalid_data(self):
+        response = self.client.post(reverse('todo_update', args=[self.todo_not_completed.id]), {
+            'task_name': '',
+            'task_description': 'Updated desc',
+            'is_completed': True
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(response, 'form', 'task_name', 'This field is required.')
+        self.todo_not_completed.refresh_from_db()
+        self.assertEqual(self.todo_not_completed.task_name, 'Incomplete Task')
+        self.assertEqual(self.todo_not_completed.task_description, 'Not done yet')
+        self.assertFalse(self.todo_not_completed.is_completed)
+
+    def test_delete_todo(self):
+        response = self.client.post(reverse('todo_delete', args=[self.todo_completed.id]))
+        self.assertEqual(Todo.objects.count(), 1)
+        self.assertRedirects(response, reverse('todo_list'))
+
+    def test_delete_todo_with_invalid_id(self):
+        invalid_id = 9999
+        response = self.client.post(reverse('todo_delete', args=[invalid_id]))
+        self.assertEqual(response.status_code, 404)

--- a/todo_app/views.py
+++ b/todo_app/views.py
@@ -8,7 +8,14 @@ class TodoListView(ListView):
     context_object_name = 'todos'
 
     def get_queryset(self):
-        return Todo.objects.all()
+        filter_val = self.request.GET.get('filter', 'completed')
+
+        if filter_val == 'completed':
+            return Todo.objects.filter(is_completed=True)
+        elif filter_val == 'not_completed':
+            return Todo.objects.filter(is_completed=False)
+        else:
+            return Todo.objects.all()
 
 class TodoCreateView(CreateView):
     model = Todo


### PR DESCRIPTION
### PR Description
This PR implements filtering functionality in the Todo list view, allowing users to toggle between viewing all tasks, only completed tasks, or only incomplete tasks.

### Summary:
- Added a filter query parameter to the TodoListView to filter todos by completion status.
- Updated the template to include radio buttons for selecting the filter, with the default filter showing completed tasks.
- Implemented auto-submit on radio button change for seamless user experience.